### PR TITLE
Address GitHub issues: security, persistence, performance (repair/config/IoT)

### DIFF
--- a/AR Car Project/Assets/Editor/ArCarDependencyHint.cs
+++ b/AR Car Project/Assets/Editor/ArCarDependencyHint.cs
@@ -1,0 +1,32 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// After clone, missing UPM packages can leave scripts uncompilable (issue #6). Logs a clear hint if AR Foundation types are absent.
+/// </summary>
+[InitializeOnLoad]
+static class ArCarDependencyHint
+{
+    static ArCarDependencyHint()
+    {
+        EditorApplication.delayCall += Check;
+    }
+
+    static void Check()
+    {
+        try
+        {
+            Type t = Type.GetType("UnityEngine.XR.ARFoundation.ARTrackedImageManager, Unity.XR.ARFoundation");
+            if (t == null)
+                Debug.LogWarning(
+                    "[ar-car] XR packages appear missing. From Unity: Window → Package Manager → refresh, or re-open the project so manifest.json dependencies resolve.");
+        }
+        catch
+        {
+            /* ignore */
+        }
+    }
+}
+#endif

--- a/AR Car Project/Assets/Editor/ArCarDependencyHint.cs.meta
+++ b/AR Car Project/Assets/Editor/ArCarDependencyHint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f60718293a4b5c6d7e8f90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AR Car Project/Assets/Prefabs/RepTaskTitle.prefab
+++ b/AR Car Project/Assets/Prefabs/RepTaskTitle.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4850268930724870955}
   - component: {fileID: 4850268930724870953}
   - component: {fileID: 4850268930724870952}
+  - component: {fileID: 4850268930724870949}
   m_Layer: 5
   m_Name: RepTaskTitle
   m_TagString: Untagged
@@ -78,6 +79,19 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4850268930724870949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4850268930724870954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c4f8e2a9d1b4e6f80305060708090ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  titleText: {fileID: 4850268932211894952}
 --- !u!1 &4850268931440756333
 GameObject:
   m_ObjectHideFlags: 0

--- a/AR Car Project/Assets/Prefabs/StepPanel.prefab
+++ b/AR Car Project/Assets/Prefabs/StepPanel.prefab
@@ -227,6 +227,7 @@ GameObject:
   - component: {fileID: 1760928147739856805}
   - component: {fileID: 1760928147739856804}
   - component: {fileID: 1760928147739856826}
+  - component: {fileID: 1760928147739856828}
   m_Layer: 5
   m_Name: StepPanel
   m_TagString: Untagged
@@ -322,6 +323,22 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &1760928147739856828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1760928147739856806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4e7f9a2c5d801234567890abcdef01, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stepId: {fileID: 1760928147571942410}
+  screenshot: {fileID: 1760928148329611319}
+  notes: {fileID: 1760928149375432412}
+  checkBox: {fileID: 1760928148704546131}
 --- !u!1 &1760928148203391422
 GameObject:
   m_ObjectHideFlags: 0

--- a/AR Car Project/Assets/Scenes/Main.unity
+++ b/AR Car Project/Assets/Scenes/Main.unity
@@ -9317,6 +9317,9 @@ MonoBehaviour:
   okBtn: {fileID: 8277904187734646854}
   closeStepBtn: {fileID: 1397174154}
   animator: {fileID: 3456807736349958163}
+  blynkToken: 
+  getUrlBase: https://blynk.cloud/external/api/get?token=
+  updateUrlBase: https://blynk.cloud/external/api/update?token=
 --- !u!4 &1064460300
 Transform:
   m_ObjectHideFlags: 0
@@ -17237,6 +17240,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5672684568260752696}
   - component: {fileID: 5672684568260752697}
+  - component: {fileID: 5672684568260752698}
   m_Layer: 0
   m_Name: Car
   m_TagString: Untagged
@@ -22398,6 +22402,7 @@ MonoBehaviour:
   showHistory: {fileID: 1469635017}
   closeProtBtn: {fileID: 320943036}
   history: {fileID: 818182914}
+  animatorBindings: {fileID: 5672684568260752698}
 --- !u!224 &3068501790835691558
 RectTransform:
   m_ObjectHideFlags: 0
@@ -26872,6 +26877,26 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &5672684568260752698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 183578317406911172}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e6f0a4c1d3e5f8a92021222324252627, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  namedAnimators:
+  - objectName: Wheelend
+    animator: {fileID: 2074642561}
+  - objectName: Body
+    animator: {fileID: 3456807736349958163}
+  - objectName: Car
+    animator: {fileID: 5672684568260752697}
+  idleStateName: Empty
 --- !u!4 &5673203565983245810
 Transform:
   m_ObjectHideFlags: 0

--- a/AR Car Project/Assets/Scripts/AnimatorRepairBindings.cs
+++ b/AR Car Project/Assets/Scripts/AnimatorRepairBindings.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Maps animator GameObject names used by repair steps to cached <see cref="Animator"/> references (replaces GameObject.Find).
+/// </summary>
+public sealed class AnimatorRepairBindings : MonoBehaviour
+{
+    [Serializable]
+    public struct NamedAnimator
+    {
+        public string objectName;
+        public Animator animator;
+    }
+
+    [SerializeField] NamedAnimator[] namedAnimators;
+    [SerializeField] string idleStateName = "Empty";
+
+    Dictionary<string, Animator> _byName;
+
+    void Awake() => BuildMap();
+
+    void BuildMap()
+    {
+        if (_byName != null)
+            return;
+
+        _byName = new Dictionary<string, Animator>(StringComparer.Ordinal);
+        if (namedAnimators == null)
+            return;
+
+        for (int i = 0; i < namedAnimators.Length; i++)
+        {
+            NamedAnimator na = namedAnimators[i];
+            if (string.IsNullOrEmpty(na.objectName) || na.animator == null)
+                continue;
+            _byName[na.objectName] = na.animator;
+        }
+    }
+
+    public bool TryGetAnimator(string objectName, out Animator animator)
+    {
+        BuildMap();
+
+        if (string.IsNullOrEmpty(objectName))
+        {
+            animator = null;
+            return false;
+        }
+
+        return _byName.TryGetValue(objectName, out animator);
+    }
+
+    /// <summary>
+    /// Returns animators to the idle pose without relying on animator transitions (issue #11 — deterministic end state).
+    /// </summary>
+    public void ResetAllToIdle()
+    {
+        if (_byName == null)
+            return;
+
+        foreach (var kv in _byName)
+        {
+            Animator a = kv.Value;
+            if (a != null && !string.IsNullOrEmpty(idleStateName))
+                a.Play(idleStateName, 0, 0f);
+        }
+    }
+}

--- a/AR Car Project/Assets/Scripts/AnimatorRepairBindings.cs.meta
+++ b/AR Car Project/Assets/Scripts/AnimatorRepairBindings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e6f0a4c1d3e5f8a92021222324252627
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AR Car Project/Assets/Scripts/ConfigCar.cs
+++ b/AR Car Project/Assets/Scripts/ConfigCar.cs
@@ -1,144 +1,146 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class ConfigCar : MonoBehaviour
+/// <summary>
+/// Cycles car assembly variants; variant roots are wired in the Inspector (issue #1 — no GameObject.Find).
+/// </summary>
+public sealed class ConfigCar : MonoBehaviour
 {
-    public Text propertyText;
-    public Text variantText;
-    public List<string> variants;    
-    public Button nextBtn;
-    public Button prevBtn;
-    public Material bodyMat;
+    [Serializable]
+    sealed class VariantRoot
+    {
+        [SerializeField] string variantName;
+        [SerializeField] GameObject root;
+
+        public string VariantName => variantName;
+        public GameObject Root => root;
+    }
+
+    [SerializeField] Text propertyText;
+    [SerializeField] Text variantText;
+    [SerializeField] List<string> variants = new List<string>();
+    [SerializeField] Button nextBtn;
+    [SerializeField] Button prevBtn;
+    [SerializeField] Material bodyMat;
+    [SerializeField] List<VariantRoot> variantRoots = new List<VariantRoot>();
+
+    Dictionary<string, GameObject> _variantByName;
+
+    void Awake()
+    {
+        _variantByName = new Dictionary<string, GameObject>(StringComparer.Ordinal);
+        for (int i = 0; i < variantRoots.Count; i++)
+        {
+            VariantRoot vr = variantRoots[i];
+            if (vr.Root != null && !string.IsNullOrEmpty(vr.VariantName))
+                _variantByName[vr.VariantName] = vr.Root;
+        }
+
+        if (propertyText == null || propertyText.text == "Color")
+            return;
+
+        for (int i = 0; i < variants.Count; i++)
+        {
+            string v = variants[i];
+            if (string.IsNullOrEmpty(v) || _variantByName.ContainsKey(v))
+                continue;
+
+            GameObject found = GameObject.Find(v);
+            if (found != null)
+            {
+                _variantByName[v] = found;
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+                Debug.LogWarning(
+                    $"ConfigCar on '{name}': variant '{v}' was resolved via GameObject.Find. " +
+                    "Assign variant roots in the Inspector to avoid runtime hierarchy scans.");
+#endif
+            }
+        }
+    }
 
     void Start()
-    {   
-        //display property text as objects name
+    {
         propertyText.text = transform.name;
-        //initialize variant text e.g. "Choose steering"
         variantText.text = "Choose " + propertyText.text.ToLower();
 
         bool isPropertyColor = propertyText.text == "Color";
 
-        nextBtn.onClick.AddListener(() => 
-        { string newVariant = NextBtnPressed(variants, variantText);
-          ChangeVariant(variants, newVariant, isPropertyColor);
+        nextBtn.onClick.AddListener(() =>
+        {
+            string newVariant = NextBtnPressed(variants, variantText);
+            ChangeVariant(newVariant, isPropertyColor);
         });
 
-        prevBtn.onClick.AddListener(() => 
-        { string newVariant = PrevBtnPressed(variants, variantText);
-            ChangeVariant(variants, newVariant, isPropertyColor);
+        prevBtn.onClick.AddListener(() =>
+        {
+            string newVariant = PrevBtnPressed(variants, variantText);
+            ChangeVariant(newVariant, isPropertyColor);
         });
     }
-    
-    //display next variant text
-    string NextBtnPressed(List<string> variants, Text variantText)
-    {
-        int currVarIdx = variants.IndexOf(variantText.text);
 
-        if (currVarIdx >= variants.Count - 1)
-        {
+    static string NextBtnPressed(List<string> variantsList, Text variantLabel)
+    {
+        int currVarIdx = variantsList.IndexOf(variantLabel.text);
+        if (currVarIdx >= variantsList.Count - 1)
             currVarIdx = 0;
-        }
         else
-        {
             currVarIdx++;
-        }
 
-        variantText.text = variants[currVarIdx];
-
-        return variantText.text;
+        variantLabel.text = variantsList[currVarIdx];
+        return variantLabel.text;
     }
 
-    //display previous variant text
-    string PrevBtnPressed(List<string> variants, Text variantText)
+    static string PrevBtnPressed(List<string> variantsList, Text variantLabel)
     {
-        int currVarIdx = variants.IndexOf(variantText.text);
-
+        int currVarIdx = variantsList.IndexOf(variantLabel.text);
         if (currVarIdx <= 0)
-        {
-            currVarIdx = variants.Count - 1;
-        }
+            currVarIdx = variantsList.Count - 1;
         else
-        {
             currVarIdx--;
-        }
 
-        variantText.GetComponent<Text>().text = variants[currVarIdx];
-
-        return variantText.text;        
+        variantLabel.text = variantsList[currVarIdx];
+        return variantLabel.text;
     }
 
-    //change variant to current variant displayed
-    void ChangeVariant(List<string> variants, string newVariant, bool isColor)
+    void ChangeVariant(string newVariant, bool isColor)
     {
-        if(!isColor)
+        if (!isColor)
         {
             foreach (string variant in variants)
             {
-                GameObject variantModel = GameObject.Find(variant);
-                if (variant == newVariant)
+                if (!_variantByName.TryGetValue(variant, out GameObject variantModel) || variantModel == null)
                 {
-                    //display new variant selected
-                    variantModel.transform.localScale = new Vector3(1, 1, 1);
+                    Debug.LogWarning($"ConfigCar: assign variant root for '{variant}' in the Inspector.");
+                    continue;
                 }
-                else
-                {
-                    //hide all other variants
-                    variantModel.transform.localScale = new Vector3(0, 0, 0);
-                }
+
+                bool show = variant == newVariant;
+                variantModel.transform.localScale = show ? Vector3.one : Vector3.zero;
             }
         }
         else
-        {              
-            string currColorText = newVariant.ToLower();
-            Color currColor; 
-
-            switch(currColorText)
+        {
+            string currColorText = newVariant.ToLowerInvariant();
+            Color currColor = currColorText switch
             {
-                case "blue":
-                    currColor = new Color32(45, 190, 240, 70);
-                    break;
-                case "rose gold":
-                    currColor = new Color32(240, 155, 125, 70);
-                    break;
-                case "goblin":
-                    currColor = new Color32(45, 170, 75, 70);
-                    break;
-                case "olive":
-                    currColor = new Color32(180, 190, 50, 70);
-                    break;
-                case "silver":
-                    currColor = new Color32(140, 170, 230, 70);
-                    break;
-                case "rosa":
-                    currColor = new Color32(230, 140, 165, 70);
-                    break;
-                case "golden":
-                    currColor = new Color32(230, 210, 140, 70);
-                    break;
-                case "green":
-                    currColor = new Color32(150, 230, 140, 70);
-                    break;
-                case "cyan":
-                    currColor = new Color32(140, 230, 220, 70);
-                    break;
-                case "sky":
-                    currColor = new Color32(140, 200, 230, 70);
-                    break;
-                case "violet":
-                    currColor = new Color32(170, 140, 230, 70);
-                    break;
-                case "white":
-                    currColor = new Color32(255, 255, 255, 70);
-                    break;
-                default:
-                    currColor = new Color32(45, 190, 240, 70);
-                    break;
-            }              
+                "blue" => new Color32(45, 190, 240, 70),
+                "rose gold" => new Color32(240, 155, 125, 70),
+                "goblin" => new Color32(45, 170, 75, 70),
+                "olive" => new Color32(180, 190, 50, 70),
+                "silver" => new Color32(140, 170, 230, 70),
+                "rosa" => new Color32(230, 140, 165, 70),
+                "golden" => new Color32(230, 210, 140, 70),
+                "green" => new Color32(150, 230, 140, 70),
+                "cyan" => new Color32(140, 230, 220, 70),
+                "sky" => new Color32(140, 200, 230, 70),
+                "violet" => new Color32(170, 140, 230, 70),
+                "white" => new Color32(255, 255, 255, 70),
+                _ => new Color32(45, 190, 240, 70)
+            };
 
-            //change material color            
             bodyMat.SetColor("_Color", currColor);
-        }        
+        }
     }
 }

--- a/AR Car Project/Assets/Scripts/ConfigCar.cs
+++ b/AR Car Project/Assets/Scripts/ConfigCar.cs
@@ -38,7 +38,8 @@ public sealed class ConfigCar : MonoBehaviour
                 _variantByName[vr.VariantName] = vr.Root;
         }
 
-        if (propertyText == null || propertyText.text == "Color")
+        // Use GameObject name — label text may still be placeholder ("PropertyText") before Start().
+        if (propertyText == null || transform.name == "Color")
             return;
 
         for (int i = 0; i < variants.Count; i++)

--- a/AR Car Project/Assets/Scripts/EditMaterial.cs
+++ b/AR Car Project/Assets/Scripts/EditMaterial.cs
@@ -1,12 +1,15 @@
 using UnityEngine;
 using UnityEngine.UI;
 
-public class EditMaterial : MonoBehaviour
+/// <summary>
+/// Toggles material between opaque (main UI) and fade (configurator) modes.
+/// </summary>
+public sealed class EditMaterial : MonoBehaviour
 {
-    public Button openMainPageBtn, openConfigPageBtn;
+    [SerializeField] Button openMainPageBtn;
+    [SerializeField] Button openConfigPageBtn;
 
-    public Material material;
-    public enum BlendMode { Opaque, Cutout, Fade, Transparent }    
+    [SerializeField] Material material;
 
     void Start()
     {

--- a/AR Car Project/Assets/Scripts/IoT.cs
+++ b/AR Car Project/Assets/Scripts/IoT.cs
@@ -1,62 +1,125 @@
-using System;
 using System.Collections;
 using UnityEngine;
-using UnityEngine.UI;
 using UnityEngine.Networking;
+using UnityEngine.UI;
 
-public class IoT : MonoBehaviour
+/// <summary>
+/// Blynk bridge: brake lights and door sensor. Token must be set in the Inspector or config asset — never committed (issue: security).
+/// </summary>
+public sealed class IoT : MonoBehaviour
 {
-    public Button bckBtn, fwdBtn, midBtn;
-    public Button okBtn, closeStepBtn;
-    public Animator animator;
+    [SerializeField] Button bckBtn;
+    [SerializeField] Button fwdBtn;
+    [SerializeField] Button midBtn;
+    [SerializeField] Button okBtn;
+    [SerializeField] Button closeStepBtn;
+    [SerializeField] Animator animator;
 
-    //device token
-    private string token = "CFy5FiOPmded4t69LfepCaRi83FWaY0Y";
-    private string getUrl = "https://blynk.cloud/external/api/get?token=";
-    private string updateUrl = "https://blynk.cloud/external/api/update?token=";
-    private int sensorVal = 100;
+    [Tooltip("Blynk device auth token. Prefer a ScriptableObject / remote config in production; do not commit real tokens.")]
+    [SerializeField] string blynkToken;
+
+    [SerializeField] string getUrlBase = "https://blynk.cloud/external/api/get?token=";
+    [SerializeField] string updateUrlBase = "https://blynk.cloud/external/api/update?token=";
+
+    const int DoorSensorPin = 14;
+    int _sensorVal = 100;
+    Coroutine _pollCoroutine;
+    bool _pollRequested;
 
     void Start()
     {
-        //turn on brake lights or v1 = 1
-        bckBtn.onClick.AddListener(delegate { StartCoroutine(UpdateValue($"{updateUrl}{token}&v1=1")); });
-        //turn off brake lights or v1 = 0
-        fwdBtn.onClick.AddListener(delegate { StartCoroutine(UpdateValue($"{updateUrl}{token}&v1=0")); });
+        if (string.IsNullOrEmpty(blynkToken))
+        {
+            Debug.LogError("IoT: Assign blynkToken in the Inspector (use a non-committed config). IoT controls are disabled.");
+            return;
+        }
+
+        string tokenParam = blynkToken;
+        bckBtn.onClick.AddListener(() => StartCoroutine(UpdateValue($"{updateUrlBase}{tokenParam}&v1=1")));
+        fwdBtn.onClick.AddListener(() => StartCoroutine(UpdateValue($"{updateUrlBase}{tokenParam}&v1=0")));
         midBtn.onClick.AddListener(CloseDoor);
-        //read sensor values
-        okBtn.onClick.AddListener(delegate { StartCoroutine(GetValue($"{getUrl}{token}&v14")); });
-        closeStepBtn.onClick.AddListener(delegate { StartCoroutine(GetValue($"{getUrl}{token}&v14")); });
+        okBtn.onClick.AddListener(StartPollingDoorSensor);
+        closeStepBtn.onClick.AddListener(StopPollingDoorSensor);
     }
 
-    IEnumerator UpdateValue(string uri)
+    void OnDisable()
     {
-        using (UnityWebRequest webRequest = UnityWebRequest.Get(uri))
+        StopPollingDoorSensor();
+    }
+
+    void StartPollingDoorSensor()
+    {
+        if (string.IsNullOrEmpty(blynkToken))
+            return;
+
+        _pollRequested = true;
+        if (_pollCoroutine != null)
+            return;
+
+        string uri = $"{getUrlBase}{blynkToken}&v{DoorSensorPin}";
+        _pollCoroutine = StartCoroutine(PollSensorLoop(uri));
+    }
+
+    void StopPollingDoorSensor()
+    {
+        _pollRequested = false;
+        if (_pollCoroutine != null)
         {
-            yield return webRequest.SendWebRequest();            
+            StopCoroutine(_pollCoroutine);
+            _pollCoroutine = null;
         }
     }
 
-    public IEnumerator GetValue(string uri)
+    IEnumerator PollSensorLoop(string uri)
     {
-        while(true)
+        while (_pollRequested)
         {
             using (UnityWebRequest webRequest = UnityWebRequest.Get(uri))
             {
                 yield return webRequest.SendWebRequest();
-                sensorVal = Int32.Parse(webRequest.downloadHandler.text);
-                Debug.Log(sensorVal);
+
+#if UNITY_2020_2_OR_NEWER
+                if (webRequest.result != UnityWebRequest.Result.Success)
+#else
+                if (webRequest.isNetworkError || webRequest.isHttpError)
+#endif
+                {
+                    Debug.LogWarning($"IoT GET failed: {webRequest.error}");
+                    yield return new WaitForSeconds(0.5f);
+                    continue;
+                }
+
+                string body = webRequest.downloadHandler.text;
+                if (int.TryParse(body.Trim(), out int v))
+                    _sensorVal = v;
+
+                OpenDoor();
             }
-            OpenDoor();
+
             yield return new WaitForSeconds(0.5f);
-        }                      
+        }
+
+        _pollCoroutine = null;
+    }
+
+    static IEnumerator UpdateValue(string uri)
+    {
+        using (UnityWebRequest webRequest = UnityWebRequest.Get(uri))
+        {
+            yield return webRequest.SendWebRequest();
+#if UNITY_2020_2_OR_NEWER
+            if (webRequest.result != UnityWebRequest.Result.Success)
+#else
+            if (webRequest.isNetworkError || webRequest.isHttpError)
+#endif
+                Debug.LogWarning($"IoT update failed: {webRequest.error}");
+        }
     }
 
     void OpenDoor()
     {
-        if (sensorVal < 50)
-        {
+        if (_sensorVal < 50)
             animator.Play("DoorLOpen");
-        }                      
     }
 
     void CloseDoor()

--- a/AR Car Project/Assets/Scripts/QuitManager.cs
+++ b/AR Car Project/Assets/Scripts/QuitManager.cs
@@ -1,9 +1,20 @@
 using UnityEngine;
 
-public class QuitManager : MonoBehaviour
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+/// <summary>
+/// Exits play mode in the Editor and quits on device builds (issue #10).
+/// </summary>
+public sealed class QuitManager : MonoBehaviour
 {
     public void QuitGame()
     {
+#if UNITY_EDITOR
+        EditorApplication.isPlaying = false;
+#else
         Application.Quit();
+#endif
     }
 }

--- a/AR Car Project/Assets/Scripts/RepairCar.cs
+++ b/AR Car Project/Assets/Scripts/RepairCar.cs
@@ -1,68 +1,111 @@
 using System;
-using System.IO;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 
-public class RepairCar : MonoBehaviour
+/// <summary>
+/// Digital repair manual UI: step flow, screenshots, protocol generation (issues #1–#5, #9).
+/// </summary>
+public sealed class RepairCar : MonoBehaviour
 {
-    //repair task buttons
-    public Button repairSuspensionBtn, repairBrakesBtn, repairSteeringBtn, showProtBtn;
-    //instruction panel items
-    public Button nextStepBtn, prevStepBtn, screenshotBtn, closeBtn;
-    public Text stepTitle, stepText;
-    public Toggle checkBox;
-    public InputField notes;
-    public GameObject ssTaken; //screenshot taken text
-    //controller items
-    public Button fwdBtn, bckBtn, midBtn;
-    //save protocol popup items
-    public Button saveBtn;
-    //display protocol items
-    public TextMeshProUGUI protocolName;
-    public InputField technician, location, problem, conclusion;
-    public GameObject repTaskPrefab, stepPrefab;
-    public Transform prefabParent;
-    public Texture2D nullTex;
-    public Button showHistory, closeProtBtn;
-    public TextMeshProUGUI history;
+    const string StepTitleFormat = "Step {0}";
 
-    private Protocol protocol;
-    private RepairTask currRepairTask;
-    private int currStepIdx;
-    private Animator animator;
+    [Header("Repair actions")]
+    [SerializeField] Button repairSuspensionBtn;
+    [SerializeField] Button repairBrakesBtn;
+    [SerializeField] Button repairSteeringBtn;
+    [SerializeField] Button showProtBtn;
+
+    [Header("Instruction panel")]
+    [SerializeField] Button nextStepBtn;
+    [SerializeField] Button prevStepBtn;
+    [SerializeField] Button screenshotBtn;
+    [SerializeField] Button closeBtn;
+    [SerializeField] Text stepTitle;
+    [SerializeField] Text stepText;
+    [SerializeField] Toggle checkBox;
+    [SerializeField] InputField notes;
+    [SerializeField] GameObject ssTaken;
+
+    [Header("Car remote")]
+    [SerializeField] Button fwdBtn;
+    [SerializeField] Button bckBtn;
+    [SerializeField] Button midBtn;
+
+    [Header("Protocol")]
+    [SerializeField] Button saveBtn;
+    [SerializeField] TextMeshProUGUI protocolName;
+    [SerializeField] InputField technician;
+    [SerializeField] InputField location;
+    [SerializeField] InputField problem;
+    [SerializeField] InputField conclusion;
+    [SerializeField] GameObject repTaskPrefab;
+    [SerializeField] GameObject stepPrefab;
+    [SerializeField] Transform prefabParent;
+    [SerializeField] Texture2D nullTex;
+    [SerializeField] Button showHistory;
+    [SerializeField] Button closeProtBtn;
+    [SerializeField] TextMeshProUGUI history;
+
+    [Header("AR repair animators")]
+    [SerializeField] AnimatorRepairBindings animatorBindings;
+
+    Protocol _protocol;
+    RepairTask _currRepairTask;
+    int _currStepIdx;
+
+    SimpleGameObjectPool _titlePool;
+    SimpleGameObjectPool _stepPool;
+
+    static string TempScreenshotPath => Path.Combine(Application.persistentDataPath, "temp.png");
+
+    void Awake()
+    {
+        if (prefabParent != null && repTaskPrefab != null && stepPrefab != null)
+        {
+            _titlePool = new SimpleGameObjectPool(repTaskPrefab, prefabParent);
+            _stepPool = new SimpleGameObjectPool(stepPrefab, prefabParent);
+        }
+    }
 
     void Start()
     {
-        repairBrakesBtn.onClick.AddListener(() =>
+        _protocol = ProtocolPersistence.LoadOrCreate();
+        if (technician != null) technician.text = _protocol.Technician ?? "";
+        if (location != null) location.text = _protocol.Location ?? "";
+        if (problem != null) problem.text = _protocol.Problem ?? "";
+        if (conclusion != null) conclusion.text = _protocol.Conclusion ?? "";
+
+        repairBrakesBtn?.onClick.AddListener(() =>
         {
-            currRepairTask = new RepairTask("Repair Brakes", new List<Step>() 
-            { 
-                new Step("Check if engine is off", "Wheelend", "BrakesS1"), 
-                new Step("Unscrew wheel nuts and pull out wheels", "Wheelend", "BrakesS2"), 
-                new Step("Remove disc brakes", "Wheelend", "BrakesS3"), 
-                new Step("Separate brake calipers and change pads") 
+            _currRepairTask = new RepairTask("Repair Brakes", new List<Step>
+            {
+                new Step("Check if engine is off", "Wheelend", "BrakesS1"),
+                new Step("Unscrew wheel nuts and pull out wheels", "Wheelend", "BrakesS2"),
+                new Step("Remove disc brakes", "Wheelend", "BrakesS3"),
+                new Step("Separate brake calipers and change pads")
             });
-            InitInfo(); //initialize display instruction text/info           
+            InitInfo();
         });
 
-        repairSuspensionBtn.onClick.AddListener(() =>
+        repairSuspensionBtn?.onClick.AddListener(() =>
         {
-            currRepairTask = new RepairTask("Repair Suspension", new List<Step>() 
+            _currRepairTask = new RepairTask("Repair Suspension", new List<Step>
             {
                 new Step("Check if engine is off", "Body", "HoodOpen"),
-                new Step("Open the hood", "Car", "EngineLift"), 
-                new Step("Lift the engine out", "Car", "SpringLift"), 
+                new Step("Open the hood", "Car", "EngineLift"),
+                new Step("Lift the engine out", "Car", "SpringLift"),
                 new Step("Remove the springs and insert new")
             });
             InitInfo();
         });
 
-        repairSteeringBtn.onClick.AddListener(() =>
+        repairSteeringBtn?.onClick.AddListener(() =>
         {
-            currRepairTask = new RepairTask("Repair Steering", new List<Step>() 
+            _currRepairTask = new RepairTask("Repair Steering", new List<Step>
             {
                 new Step("Check if engine is off", "Body", "HoodOpen"),
                 new Step("Open the hood", "Car", "EngineLift"),
@@ -72,185 +115,270 @@ public class RepairCar : MonoBehaviour
             InitInfo();
         });
 
-        //instruction panel
-        nextStepBtn.onClick.AddListener(() => ShowNextStep(currRepairTask.Steps));
-        prevStepBtn.onClick.AddListener(() => ShowPrevStep(currRepairTask.Steps));
-        screenshotBtn.onClick.AddListener(() => StartCoroutine(TakeScreenshot()));
-        closeBtn.onClick.AddListener(() =>
+        nextStepBtn?.onClick.AddListener(() =>
         {
-            //bring back car original state or fully assembled
-            StartCoroutine(ResetCar(currRepairTask.Steps));
-            StoreStepInfo(currRepairTask.Steps[currStepIdx]);                    
+            if (_currRepairTask?.Steps != null)
+                ShowNextStep(_currRepairTask.Steps);
         });
 
-        //initialize protocol
-        protocol = new Protocol($"P {DateTime.Now.ToString()}", new List<RepairTask>());
-
-        //save or add repair task to protocol
-        saveBtn.onClick.AddListener(() => protocol.RepairTasks.Add(currRepairTask));      
-
-        //protocol popup
-        showProtBtn.onClick.AddListener(GenerateProtocol);
-        closeProtBtn.onClick.AddListener(StoreProtocolInfo);
-        showHistory.onClick.AddListener(() =>
+        prevStepBtn?.onClick.AddListener(() =>
         {
-            //store infos from inputfields
+            if (_currRepairTask?.Steps != null)
+                ShowPrevStep(_currRepairTask.Steps);
+        });
+
+        screenshotBtn?.onClick.AddListener(() => StartCoroutine(TakeScreenshot()));
+
+        closeBtn?.onClick.AddListener(() =>
+        {
+            if (_currRepairTask?.Steps == null)
+                return;
+
+            StartCoroutine(ResetCar(_currRepairTask.Steps));
+            StoreStepInfo(_currRepairTask.Steps[_currStepIdx]);
+        });
+
+        saveBtn?.onClick.AddListener(() =>
+        {
+            if (_currRepairTask != null)
+            {
+                _protocol.RepairTasks.Add(_currRepairTask);
+                StoreProtocolInfo();
+                ProtocolPersistence.Save(_protocol);
+            }
+        });
+
+        showProtBtn?.onClick.AddListener(GenerateProtocol);
+        closeProtBtn?.onClick.AddListener(() =>
+        {
             StoreProtocolInfo();
-            protocol.GenerateHistory(protocol.RepairTasks, history);
+            ProtocolPersistence.Save(_protocol);
+        });
+
+        showHistory?.onClick.AddListener(() =>
+        {
+            StoreProtocolInfo();
+            ProtocolPersistence.Save(_protocol);
+            _protocol.GenerateHistory(_protocol.RepairTasks, history);
         });
     }
 
     void InitInfo()
     {
-        //initialize repair step variables 
-        currStepIdx = 0;
-        prevStepBtn.interactable = false;
-        nextStepBtn.interactable = true;
-        //initialize text and checkbox
-        stepTitle.text = "Step 0";
-        stepText.text = currRepairTask.Steps[0].StepText;
-        checkBox.isOn = currRepairTask.Steps[0].IsDone;
-        notes.text = currRepairTask.Steps[0].Notes;
-        //disable all other buttons
-        List<Button> btns = new List<Button>() { repairSteeringBtn, repairSuspensionBtn, repairBrakesBtn , fwdBtn, bckBtn, midBtn };
-        foreach(Button btn in btns)
-        {
-            btn.enabled = false;
-        }     
+        if (_currRepairTask?.Steps == null || _currRepairTask.Steps.Count == 0)
+            return;
+
+        _currStepIdx = 0;
+        if (prevStepBtn != null)
+            prevStepBtn.interactable = false;
+        if (nextStepBtn != null)
+            nextStepBtn.interactable = true;
+
+        stepTitle.text = string.Format(StepTitleFormat, 0);
+        stepText.text = _currRepairTask.Steps[0].StepText;
+        checkBox.isOn = _currRepairTask.Steps[0].IsDone;
+        notes.text = _currRepairTask.Steps[0].Notes;
+
+        SetRepairButtonsInteractable(false);
+    }
+
+    void SetRepairButtonsInteractable(bool enabled)
+    {
+        if (repairSteeringBtn != null) repairSteeringBtn.interactable = enabled;
+        if (repairSuspensionBtn != null) repairSuspensionBtn.interactable = enabled;
+        if (repairBrakesBtn != null) repairBrakesBtn.interactable = enabled;
+        if (fwdBtn != null) fwdBtn.interactable = enabled;
+        if (bckBtn != null) bckBtn.interactable = enabled;
+        if (midBtn != null) midBtn.interactable = enabled;
     }
 
     void ShowNextStep(List<Step> steps)
     {
         prevStepBtn.interactable = true;
-        
-        Step currStep = steps[currStepIdx]; //current step
+
+        Step currStep = steps[_currStepIdx];
         StoreStepInfo(currStep);
 
-        if (currStepIdx < steps.Count - 1)
+        if (_currStepIdx < steps.Count - 1)
         {
-            //show animation            
-            animator = GameObject.Find(currStep.AnimatorName).GetComponent<Animator>();
-            animator.Play(currStep.AnimationName);
-            //go to next step
-            currStepIdx++;
-            currStep = steps[currStepIdx]; //update current step
+            PlayStepAnimation(currStep, forward: true);
+            _currStepIdx++;
+            currStep = steps[_currStepIdx];
         }
         else
         {
-            //disable next button if last element reached
             nextStepBtn.interactable = false;
         }
-        UpdateStepInfo(currStep);       
+
+        UpdateStepInfo(currStep);
     }
 
     void ShowPrevStep(List<Step> steps)
     {
-        nextStepBtn.interactable = true;        
+        nextStepBtn.interactable = true;
 
-        Step currStep = steps[currStepIdx]; //current step
+        Step currStep = steps[_currStepIdx];
         StoreStepInfo(currStep);
 
-        if (currStepIdx > 0)
-        {   
-            //go back a step
-            currStepIdx--;
-            currStep = steps[currStepIdx]; //update current step            
-            //show animation             
-            animator = GameObject.Find(currStep.AnimatorName).GetComponent<Animator>();
-            animator.Play(currStep.AnimationName + "rev"); //reverse step
+        if (_currStepIdx > 0)
+        {
+            _currStepIdx--;
+            currStep = steps[_currStepIdx];
+            PlayStepAnimation(currStep, forward: false);
         }
         else
         {
             prevStepBtn.interactable = false;
         }
+
         UpdateStepInfo(currStep);
     }
-    
+
+    void PlayStepAnimation(Step step, bool forward)
+    {
+        if (animatorBindings == null || string.IsNullOrEmpty(step.AnimatorName))
+            return;
+
+        if (!animatorBindings.TryGetAnimator(step.AnimatorName, out Animator anim))
+        {
+            Debug.LogWarning($"Repair animator not bound: '{step.AnimatorName}'");
+            return;
+        }
+
+        string stateName = forward ? step.AnimationName : step.AnimationName + "rev";
+        if (string.IsNullOrEmpty(step.AnimationName))
+            return;
+
+        anim.Play(stateName, 0, 0f);
+    }
+
     void StoreStepInfo(Step step)
     {
-        //store infos from checkbox and notes for currStep
         step.IsDone = checkBox.isOn;
         step.Notes = notes.text;
 
-        //store texture in step
-        Texture2D screenshotTex = new Texture2D(73, 73);
-        if (File.Exists(Application.persistentDataPath + "/temp.png"))
-        //if(File.Exists(Application.dataPath + "/temp.png"))
+        if (!File.Exists(TempScreenshotPath))
+            return;
+
+        byte[] imageData;
+        try
         {
-            var imageData = File.ReadAllBytes(Application.persistentDataPath + "/temp.png");
-            //var imageData = File.ReadAllBytes(Application.dataPath + "/temp.png");
-            screenshotTex.LoadImage(imageData);
+            imageData = File.ReadAllBytes(TempScreenshotPath);
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"Could not read screenshot: {e.Message}");
+            return;
+        }
+
+        if (step.ScreenshotTex != null)
+            Destroy(step.ScreenshotTex);
+
+        var screenshotTex = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+        if (screenshotTex.LoadImage(imageData))
+        {
             step.ScreenshotTex = screenshotTex;
-            File.Delete(Application.persistentDataPath + "/temp.png");
-            //File.Delete(Application.dataPath + "/temp.png");
-        }        
+            try { File.Delete(TempScreenshotPath); }
+            catch { /* ignore */ }
+        }
+        else
+        {
+            Destroy(screenshotTex);
+        }
     }
 
     void UpdateStepInfo(Step step)
     {
         stepText.text = step.StepText;
-        stepTitle.text = "Step " + currStepIdx.ToString();
+        stepTitle.text = string.Format(StepTitleFormat, _currStepIdx);
         checkBox.isOn = step.IsDone;
         notes.text = step.Notes;
     }
 
     IEnumerator ResetCar(List<Step> steps)
     {
-        int i = currStepIdx - 1;
+        int i = _currStepIdx - 1;
         while (i >= 0)
         {
             Step currStep = steps[i];
-            animator = GameObject.Find(currStep.AnimatorName).GetComponent<Animator>();
-            animator.Play(currStep.AnimationName + "rev"); //reverse step
-            //wait till animation is over
-            yield return new WaitForSeconds(animator.GetCurrentAnimatorStateInfo(0).length);
+            if (animatorBindings != null && animatorBindings.TryGetAnimator(currStep.AnimatorName, out Animator anim)
+                && !string.IsNullOrEmpty(currStep.AnimationName))
+            {
+                anim.Play(currStep.AnimationName + "rev", 0, 0f);
+                yield return new WaitForSeconds(anim.GetCurrentAnimatorStateInfo(0).length);
+            }
             i--;
-        }        
+        }
+
+        animatorBindings?.ResetAllToIdle();
+        SetRepairButtonsInteractable(true);
+    }
+
+    void ReleaseProtocolChildren()
+    {
+        if (prefabParent == null)
+            return;
+
+        for (int c = prefabParent.childCount - 1; c >= 0; c--)
+        {
+            Transform t = prefabParent.GetChild(c);
+            GameObject go = t.gameObject;
+            if (_titlePool != null && go.GetComponent<RepairTaskTitleView>() != null)
+                _titlePool.Release(go);
+            else if (_stepPool != null && go.GetComponent<StepProtocolRowView>() != null)
+                _stepPool.Release(go);
+            else
+                Destroy(go);
+        }
     }
 
     void GenerateProtocol()
     {
-        protocolName.text = protocol.ProtocolName;
+        if (_protocol == null || prefabParent == null || repTaskPrefab == null || stepPrefab == null)
+            return;
 
-        float moveRepTitle = 0f; //space between repair task title
-        float movePanel = 0f; //space between step panels
+        protocolName.text = _protocol.ProtocolName;
 
-        for (int repTaskIdx = 0; repTaskIdx < protocol.RepairTasks.Count; repTaskIdx++)
+        ReleaseProtocolChildren();
+
+        float moveRepTitle = 0f;
+        float movePanel = 0f;
+
+        for (int repTaskIdx = 0; repTaskIdx < _protocol.RepairTasks.Count; repTaskIdx++)
         {
-            RepairTask repTask = protocol.RepairTasks[repTaskIdx];
+            RepairTask repTask = _protocol.RepairTasks[repTaskIdx];
 
-            //load repair task title
-            GameObject repTaskTitle = Instantiate(repTaskPrefab);
+            GameObject repTaskTitle = _titlePool != null ? _titlePool.Get() : Instantiate(repTaskPrefab, prefabParent, false);
             repTaskTitle.transform.SetParent(prefabParent, false);
+            repTaskTitle.transform.localPosition = Vector3.zero;
+            repTaskTitle.transform.localRotation = Quaternion.identity;
+            repTaskTitle.transform.localScale = Vector3.one;
             repTaskTitle.transform.Translate(0, moveRepTitle, 0);
             repTaskTitle.name = $"R{repTaskIdx}";
-            Text repTaskText = GameObject.Find($"{repTaskTitle.name}/TitleText").GetComponent<Text>();           
-            repTaskText.text = repTask.TaskName;            
 
-            //create and load steps
+            var titleView = repTaskTitle.GetComponent<RepairTaskTitleView>();
+            if (titleView?.TitleText != null)
+                titleView.TitleText.text = repTask.TaskName;
+
             for (int stepIdx = 0; stepIdx < repTask.Steps.Count; stepIdx++)
             {
                 Step step = repTask.Steps[stepIdx];
 
-                GameObject stepPanel = Instantiate(stepPrefab);
+                GameObject stepPanel = _stepPool != null ? _stepPool.Get() : Instantiate(stepPrefab, prefabParent, false);
                 stepPanel.transform.SetParent(prefabParent, false);
-                stepPanel.transform.Translate(0, movePanel, 0); //create panels one below another
+                stepPanel.transform.localPosition = Vector3.zero;
+                stepPanel.transform.localRotation = Quaternion.identity;
+                stepPanel.transform.localScale = Vector3.one;
+                stepPanel.transform.Translate(0, movePanel, 0);
                 stepPanel.name = $"S{stepIdx}R{repTaskIdx}";
-                //load step id
-                TextMeshProUGUI stepId = GameObject.Find($"{stepPanel.name}/StepId").GetComponent<TextMeshProUGUI>();
-                stepId.text = $"Step {stepIdx}";
-                //load screenshot
-                RawImage screenshot = GameObject.Find($"{stepPanel.name}/Screenshot").GetComponent<RawImage>();
-                screenshot.texture = step.ScreenshotTex == null ? nullTex : step.ScreenshotTex;  
-                //load notes
-                TextMeshProUGUI protocolNotes = GameObject.Find($"{stepPanel.name}/Notes").GetComponent<TextMeshProUGUI>();
-                protocolNotes.text = step.Notes;
-                //load isStepComplete 
-                Toggle isDone = GameObject.Find($"{stepPanel.name}/Checkbox").GetComponent<Toggle>();
-                isDone.isOn = step.IsDone;
+
+                var row = stepPanel.GetComponent<StepProtocolRowView>();
+                if (row != null)
+                    row.Apply(stepIdx, step, nullTex);
 
                 movePanel -= 400f;
             }
+
             movePanel -= 60f;
             moveRepTitle = movePanel;
         }
@@ -258,19 +386,17 @@ public class RepairCar : MonoBehaviour
 
     void StoreProtocolInfo()
     {
-        protocol.Technician = technician.text;
-        protocol.Location = location.text;
-        protocol.Problem = problem.text;
-        protocol.Conclusion = conclusion.text;
+        _protocol.Technician = technician.text;
+        _protocol.Location = location.text;
+        _protocol.Problem = problem.text;
+        _protocol.Conclusion = conclusion.text;
     }
 
     IEnumerator TakeScreenshot()
     {
         ScreenCapture.CaptureScreenshot("temp.png");
-        //ScreenCapture.CaptureScreenshot(Application.dataPath + "/temp.png"); 
         ssTaken.SetActive(true);
         yield return new WaitForSeconds(0.5f);
         ssTaken.SetActive(false);
     }
-
 }

--- a/AR Car Project/Assets/Scripts/RepairTask.cs
+++ b/AR Car Project/Assets/Scripts/RepairTask.cs
@@ -1,9 +1,19 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using TMPro;
 
-//top node (level 0)
-public class Protocol
+/// <summary>
+/// Marks domain objects that belong to the repair protocol graph (issue #8).
+/// </summary>
+public interface IProtocolEntity { }
+
+/// <summary>
+/// Root protocol aggregate (level 0).
+/// </summary>
+[Serializable]
+public sealed class Protocol : IProtocolEntity
 {
     public string ProtocolName { get; set; }
     public string Technician { get; set; }
@@ -15,34 +25,52 @@ public class Protocol
     public Protocol(string protocolName, List<RepairTask> repairTasks)
     {
         ProtocolName = protocolName;
-        RepairTasks = repairTasks;
+        RepairTasks = repairTasks ?? new List<RepairTask>();
     }
-    
+
     public void GenerateHistory(List<RepairTask> repairTasks, TextMeshProUGUI history)
-    {        
-        string addLines = ProtocolName + "\n";     
-        addLines += $"Technician: {Technician}\nLocation: {Location}\nProblem: {Problem}\nConclusion: {Conclusion}\n";
-        addLines += "==========================\n";
-        foreach (RepairTask repairTask in repairTasks)
+    {
+        if (history == null)
+            return;
+
+        var path = ProtocolPersistence.LifecycleFilePath;
+        var sb = new System.Text.StringBuilder(512);
+        sb.Append(ProtocolName).Append('\n');
+        sb.Append("Technician: ").Append(Technician).Append("\nLocation: ").Append(Location)
+            .Append("\nProblem: ").Append(Problem).Append("\nConclusion: ").Append(Conclusion).Append('\n');
+        sb.Append("==========================\n");
+
+        for (int r = 0; r < repairTasks.Count; r++)
         {
-            addLines += $"Repair Task: {repairTask.TaskName}\n";
+            RepairTask repairTask = repairTasks[r];
+            sb.Append("Repair Task: ").Append(repairTask.TaskName).Append('\n');
             List<Step> steps = repairTask.Steps;
-            foreach (Step step in steps)
+            for (int i = 0; i < steps.Count; i++)
             {
+                Step step = steps[i];
                 string isDone = step.IsDone ? "Complete" : "Not complete";
-                addLines += $"Step {steps.IndexOf(step)}: {isDone}, Notes: {step.Notes}\n";
+                sb.Append("Step ").Append(i).Append(": ").Append(isDone).Append(", Notes: ").Append(step.Notes).Append('\n');
             }
-            addLines += "-------------------------------------\n";
+            sb.Append("-------------------------------------\n");
         }
-        //add protocol to product lifecycle document to store product history
-        System.IO.File.AppendAllText(Application.persistentDataPath + "/lifecycle.txt", addLines);
-        //display history
-        history.text = System.IO.File.ReadAllText(Application.persistentDataPath + "/lifecycle.txt");        
-    }    
+
+        try
+        {
+            File.AppendAllText(path, sb.ToString());
+            history.text = File.ReadAllText(path);
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"Could not write lifecycle history: {e.Message}");
+        }
+    }
 }
 
-//level 1 node
-public class RepairTask
+/// <summary>
+/// Single repair task with ordered steps (level 1).
+/// </summary>
+[Serializable]
+public sealed class RepairTask : IProtocolEntity
 {
     public string TaskName { get; set; }
     public List<Step> Steps { get; set; }
@@ -50,29 +78,199 @@ public class RepairTask
     public RepairTask(string taskName, List<Step> steps)
     {
         TaskName = taskName;
-        Steps = steps;
-    }        
+        Steps = steps ?? new List<Step>();
+    }
 }
 
-//level 2 node
-public class Step
+/// <summary>
+/// One instruction step with optional AR animation binding (level 2).
+/// </summary>
+[Serializable]
+public sealed class Step : IProtocolEntity
 {
     public string StepText { get; set; }
     public bool IsDone { get; set; }
     public string Notes { get; set; }
-    public Texture ScreenshotTex { get; set; }
+    /// <summary>Runtime screenshot; not written by JsonUtility — persisted via <see cref="ProtocolPersistence"/>.</summary>
+    public Texture2D ScreenshotTex { get; set; }
     public string AnimatorName { get; set; }
     public string AnimationName { get; set; }
-    //video
 
-    public Step(string stepText, string animator = null, string animationName = null, bool isDone = false,  string notes = "", Texture screenshotTex = null)
+    public Step(string stepText, string animator = null, string animationName = null, bool isDone = false, string notes = "", Texture2D screenshotTex = null)
     {
         StepText = stepText;
         IsDone = isDone;
         AnimatorName = animator;
         AnimationName = animationName;
-        Notes = notes;
+        Notes = notes ?? "";
         ScreenshotTex = screenshotTex;
     }
 }
 
+/// <summary>
+/// JSON file persistence for <see cref="Protocol"/> and step screenshot files (issue #5).
+/// </summary>
+public static class ProtocolPersistence
+{
+    public static string LifecycleFilePath => Path.Combine(Application.persistentDataPath, "lifecycle.txt");
+    static string ProtocolFilePath => Path.Combine(Application.persistentDataPath, "protocol_save.json");
+    static string ScreenshotsDir => Path.Combine(Application.persistentDataPath, "protocol_screenshots");
+
+    [Serializable]
+    sealed class FileDto
+    {
+        public string protocolName;
+        public string technician;
+        public string location;
+        public string problem;
+        public string conclusion;
+        public RepairTaskDto[] repairTasks;
+    }
+
+    [Serializable]
+    sealed class RepairTaskDto
+    {
+        public string taskName;
+        public StepDto[] steps;
+    }
+
+    [Serializable]
+    sealed class StepDto
+    {
+        public string stepText;
+        public bool isDone;
+        public string notes;
+        public string animatorName;
+        public string animationName;
+        public string screenshotFile;
+    }
+
+    public static void Save(Protocol protocol)
+    {
+        if (protocol == null)
+            return;
+
+        Directory.CreateDirectory(ScreenshotsDir);
+
+        var dto = new FileDto
+        {
+            protocolName = protocol.ProtocolName,
+            technician = protocol.Technician,
+            location = protocol.Location,
+            problem = protocol.Problem,
+            conclusion = protocol.Conclusion,
+            repairTasks = new RepairTaskDto[protocol.RepairTasks.Count]
+        };
+
+        for (int r = 0; r < protocol.RepairTasks.Count; r++)
+        {
+            RepairTask rt = protocol.RepairTasks[r];
+            var taskDto = new RepairTaskDto
+            {
+                taskName = rt.TaskName,
+                steps = new StepDto[rt.Steps.Count]
+            };
+
+            for (int s = 0; s < rt.Steps.Count; s++)
+            {
+                Step step = rt.Steps[s];
+                string shotFile = null;
+                if (step.ScreenshotTex != null)
+                {
+                    shotFile = $"r{r}_s{s}.png";
+                    string full = Path.Combine(ScreenshotsDir, shotFile);
+                    try
+                    {
+                        byte[] png = step.ScreenshotTex.EncodeToPNG();
+                        File.WriteAllBytes(full, png);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogWarning($"Failed to save screenshot {full}: {e.Message}");
+                        shotFile = null;
+                    }
+                }
+
+                taskDto.steps[s] = new StepDto
+                {
+                    stepText = step.StepText,
+                    isDone = step.IsDone,
+                    notes = step.Notes ?? "",
+                    animatorName = step.AnimatorName,
+                    animationName = step.AnimationName,
+                    screenshotFile = shotFile
+                };
+            }
+
+            dto.repairTasks[r] = taskDto;
+        }
+
+        try
+        {
+            File.WriteAllText(ProtocolFilePath, JsonUtility.ToJson(dto, true));
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"Protocol save failed: {e.Message}");
+        }
+    }
+
+    public static Protocol LoadOrCreate()
+    {
+        if (!File.Exists(ProtocolFilePath))
+            return new Protocol($"P {DateTime.Now}", new List<RepairTask>());
+
+        try
+        {
+            string json = File.ReadAllText(ProtocolFilePath);
+            var dto = JsonUtility.FromJson<FileDto>(json);
+            if (dto == null || dto.repairTasks == null)
+                return new Protocol($"P {DateTime.Now}", new List<RepairTask>());
+
+            var tasks = new List<RepairTask>(dto.repairTasks.Length);
+            for (int r = 0; r < dto.repairTasks.Length; r++)
+            {
+                RepairTaskDto td = dto.repairTasks[r];
+                var steps = new List<Step>(td.steps?.Length ?? 0);
+                if (td.steps != null)
+                {
+                    for (int s = 0; s < td.steps.Length; s++)
+                    {
+                        StepDto sd = td.steps[s];
+                        var step = new Step(sd.stepText, sd.animatorName, sd.animationName, sd.isDone, sd.notes ?? "");
+                        if (!string.IsNullOrEmpty(sd.screenshotFile))
+                        {
+                            string full = Path.Combine(ScreenshotsDir, sd.screenshotFile);
+                            if (File.Exists(full))
+                            {
+                                byte[] data = File.ReadAllBytes(full);
+                                var tex = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                                tex.name = sd.screenshotFile;
+                                if (tex.LoadImage(data))
+                                    step.ScreenshotTex = tex;
+                                else
+                                    UnityEngine.Object.Destroy(tex);
+                            }
+                        }
+                        steps.Add(step);
+                    }
+                }
+                tasks.Add(new RepairTask(td.taskName, steps));
+            }
+
+            var p = new Protocol(dto.protocolName ?? $"P {DateTime.Now}", tasks)
+            {
+                Technician = dto.technician,
+                Location = dto.location,
+                Problem = dto.problem,
+                Conclusion = dto.conclusion
+            };
+            return p;
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"Protocol load failed, using new protocol: {e.Message}");
+            return new Protocol($"P {DateTime.Now}", new List<RepairTask>());
+        }
+    }
+}

--- a/AR Car Project/Assets/Scripts/RepairTaskTitleView.cs
+++ b/AR Car Project/Assets/Scripts/RepairTaskTitleView.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Binds serialized UI on the repair-task title row prefab (avoids GameObject.Find at runtime).
+/// </summary>
+public sealed class RepairTaskTitleView : MonoBehaviour
+{
+    [SerializeField] Text titleText;
+
+    public Text TitleText => titleText;
+}

--- a/AR Car Project/Assets/Scripts/RepairTaskTitleView.cs.meta
+++ b/AR Car Project/Assets/Scripts/RepairTaskTitleView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c4f8e2a9d1b4e6f80305060708090ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AR Car Project/Assets/Scripts/SimpleGameObjectPool.cs
+++ b/AR Car Project/Assets/Scripts/SimpleGameObjectPool.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Minimal stack pool for UI prefab instances to avoid repeated Instantiate/Destroy churn.
+/// </summary>
+public sealed class SimpleGameObjectPool
+{
+    readonly Stack<GameObject> _available = new Stack<GameObject>();
+    readonly GameObject _prefab;
+    readonly Transform _parent;
+
+    public SimpleGameObjectPool(GameObject prefab, Transform parent)
+    {
+        _prefab = prefab;
+        _parent = parent;
+    }
+
+    public GameObject Get()
+    {
+        while (_available.Count > 0)
+        {
+            var go = _available.Pop();
+            if (go != null)
+            {
+                go.SetActive(true);
+                return go;
+            }
+        }
+
+        return Object.Instantiate(_prefab, _parent, false);
+    }
+
+    public void Release(GameObject instance)
+    {
+        if (instance == null)
+            return;
+        instance.SetActive(false);
+        instance.transform.SetParent(_parent, false);
+        _available.Push(instance);
+    }
+
+    public void ClearDestroyed()
+    {
+        // No-op: pool assumes releases are valid; optional cleanup could scan stack
+    }
+}

--- a/AR Car Project/Assets/Scripts/SimpleGameObjectPool.cs.meta
+++ b/AR Car Project/Assets/Scripts/SimpleGameObjectPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d5e9f3b0c2d4e7f91011121314151617
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AR Car Project/Assets/Scripts/StepProtocolRowView.cs
+++ b/AR Car Project/Assets/Scripts/StepProtocolRowView.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Binds serialized UI on the protocol step row prefab (avoids GameObject.Find at runtime).
+/// </summary>
+public sealed class StepProtocolRowView : MonoBehaviour
+{
+    [SerializeField] TextMeshProUGUI stepId;
+    [SerializeField] RawImage screenshot;
+    [SerializeField] TextMeshProUGUI notes;
+    [SerializeField] Toggle checkBox;
+
+    public void Apply(int stepIndex, Step step, Texture2D nullTex)
+    {
+        stepId.text = $"Step {stepIndex}";
+        screenshot.texture = step.ScreenshotTex == null ? nullTex : step.ScreenshotTex;
+        notes.text = step.Notes;
+        checkBox.isOn = step.IsDone;
+    }
+}

--- a/AR Car Project/Assets/Scripts/StepProtocolRowView.cs.meta
+++ b/AR Car Project/Assets/Scripts/StepProtocolRowView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4e7f9a2c5d801234567890abcdef01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR implements fixes aligned with the repository issues list (ordered by dependency/risk, not issue numbers).

### Security and reliability
- **IoT**: Removed the hardcoded Blynk token. Assign `blynkToken` on the `IoTManager` in Unity (or use a future ScriptableObject/remote config). URLs remain configurable via serialized bases.
- **IoT**: Replaced the infinite `while(true)` sensor coroutine with a cancellable poll loop that stops when disabled or when polling stops.

### Protocol and data (#5, #8)
- **`Protocol` / `RepairTask` / `Step`**: `[Serializable]` domain types with `IProtocolEntity` marker.
- **Persistence**: `ProtocolPersistence` saves/loads JSON (`persistentDataPath/protocol_save.json`) plus PNG screenshots under `protocol_screenshots/`. Lifecycle append remains `lifecycle.txt` with guarded file I/O.

### Performance (#1, #9)
- **Repair**: `AnimatorRepairBindings` maps step animator names to cached `Animator` references (wired on the `Car` root in `Main.unity`). Protocol rows use `RepairTaskTitleView` / `StepProtocolRowView` on prefabs instead of `GameObject.Find`.
- **Pooling**: `SimpleGameObjectPool` reuses protocol prefab instances across `GenerateProtocol` refreshes.

### UX / Editor (#10, #11, #6)
- **Quit**: `QuitManager` exits play mode in Editor (`UnityEditor`) and calls `Application.Quit()` on builds.
- **Animator exit**: After reversing animations when closing repair instructions, animators are driven to the shared `"Empty"` idle state via bindings.
- **Clone/load**: `Assets/Editor/ArCarDependencyHint.cs` warns when XR/ARFoundation assemblies are missing after clone.

### Configurator (#1, partial #3)
- **`ConfigCar`**: Supports Inspector-assigned `variantRoots`; for unmigrated entries still resolves names via one-time `GameObject.Find` with a dev warning. **Fix:** color rows skip `Find` using `transform.name == "Color"` (label text is still placeholder `"PropertyText"` in Awake).

## Manual steps after merge
1. In Unity, assign **`IoTManager` → Blynk Token** (do not commit real credentials).
2. Open **`Main`** scene and confirm **`RepairCar` → Animator Bindings** references the `AnimatorRepairBindings` on `Car` (serialized in YAML).

## Testing
- Not run in CI here (Unity project). Please open the project in Unity 6000.x and run Play Mode smoke tests for repair flow, protocol generation, color configurator, and IoT with a test token.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eb5ccd-7df9-42b4-9c53-2db03846623d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eb5ccd-7df9-42b4-9c53-2db03846623d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

