### PR TITLE
Fix ImageTargetEnabler for AR Foundation 6 trackablesChanged API

### DIFF
--- a/AR Car Project/Assets/Prefabs/StepPanel.prefab
+++ b/AR Car Project/Assets/Prefabs/StepPanel.prefab
@@ -332,7 +332,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1760928147739856806}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b4e7f9a2c5d801234567890abcdef01, type: 3}
+  m_Script: {fileID: 11500000, guid: b4e7f9a2c5d801234567890abcdef010, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   stepId: {fileID: 1760928147571942410}

--- a/AR Car Project/Assets/Scenes/Main.unity
+++ b/AR Car Project/Assets/Scenes/Main.unity
@@ -26917,7 +26917,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 183578317406911172}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9e6f0a4c1d3e5f8a92021222324252627, type: 3}
+  m_Script: {fileID: 11500000, guid: 9e6f0a4c1d3e5f8a9202122232425262, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   namedAnimators:

--- a/AR Car Project/Assets/Scripts/Gameplay.meta
+++ b/AR Car Project/Assets/Scripts/Gameplay.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d41e5f60718293a4b5c6d7e8f01
+guid: a1b2c3d4e5f60718293a4b5c6d7e8f01
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/AR Car Project/Assets/Scripts/Repair.meta
+++ b/AR Car Project/Assets/Scripts/Repair.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d41e5f60718293a4b5c6d7e8f02
+guid: a1b2c3d4e5f60718293a4b5c6d7e8f02
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/AR Car Project/Assets/Scripts/Repair/AnimatorRepairBindings.cs.meta
+++ b/AR Car Project/Assets/Scripts/Repair/AnimatorRepairBindings.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9e6f0a4c1d3e5f8a92021222324252627
+guid: 9e6f0a4c1d3e5f8a9202122232425262
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/AR Car Project/Assets/Scripts/Repair/SimpleGameObjectPool.cs.meta
+++ b/AR Car Project/Assets/Scripts/Repair/SimpleGameObjectPool.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d5e9f3b0c2d4e7f91011121314151617
+guid: 8d5e9f3b0c2d4e7f9101112131415161
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/AR Car Project/Assets/Scripts/Repair/StepProtocolRowView.cs.meta
+++ b/AR Car Project/Assets/Scripts/Repair/StepProtocolRowView.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b4e7f9a2c5d801234567890abcdef01
+guid: b4e7f9a2c5d801234567890abcdef010
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/AR Car Project/Assets/Scripts/XR.meta
+++ b/AR Car Project/Assets/Scripts/XR.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d41e5f60718293a4b5c6d7e8f03
+guid: a1b2c3d4e5f60718293a4b5c6d7e8f03
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/AR Car Project/Assets/Scripts/XR/ImageTargetEnabler.cs
+++ b/AR Car Project/Assets/Scripts/XR/ImageTargetEnabler.cs
@@ -31,14 +31,17 @@ public class ImageTargetEnabler : MonoBehaviour
 
     void OnTrackablesChanged(ARTrackablesChangedEventArgs<ARTrackedImage> args)
     {
-        foreach (var _ in args.removed)
+        // AR Foundation 6+: removed is KeyValuePair<TrackableId, ARTrackedImage>, not ARTrackedImage.
+        if (args.removed.Count > 0 && imageTarget != null)
             imageTarget.SetActive(false);
 
-        foreach (var img in args.added)
-            ApplyTrackedImage(img);
+        var added = args.added;
+        for (int i = 0; i < added.Count; i++)
+            ApplyTrackedImage(added[i]);
 
-        foreach (var img in args.updated)
-            ApplyTrackedImage(img);
+        var updated = args.updated;
+        for (int i = 0; i < updated.Count; i++)
+            ApplyTrackedImage(updated[i]);
     }
 
     void ApplyTrackedImage(ARTrackedImage img)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unity requires **exactly 32 hexadecimal characters** for every asset GUID. Several `.meta` files used placeholder GUIDs with **31–33 characters**, which caused:

- YAML parser warnings (“GUID cannot be extracted…”)
- “.meta file does not have a valid GUID” — folders/scripts ignored
- **RepairCar.cs CS0246** for `AnimatorRepairBindings` / `SimpleGameObjectPool` because those scripts were never imported

This PR fixes all six invalid GUIDs and updates serialized script references in **Main.unity** (AnimatorRepairBindings) and **StepPanel.prefab** (StepProtocolRowView) so existing instances still resolve.

## Testing

Not run (Unity not available here). After pull: let Unity reimport; Console meta GUID noise and compile errors for those types should clear.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ba3d211-0fd1-4a73-b642-31027fd1f137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ba3d211-0fd1-4a73-b642-31027fd1f137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

