### PR TITLE
Fix CS0012/CS0019 in ImageTargetEnabler by referencing Unity.XR.CoreUtils

### DIFF
--- a/AR Car Project/Assets/Scripts/ArCar.Runtime.asmdef
+++ b/AR Car Project/Assets/Scripts/ArCar.Runtime.asmdef
@@ -5,7 +5,8 @@
     "Unity.TextMeshPro",
     "Unity.UGUI",
     "Unity.XR.ARFoundation",
-    "Unity.XR.ARSubsystems"
+    "Unity.XR.ARSubsystems",
+    "Unity.XR.CoreUtils"
   ],
   "includePlatforms": [],
   "excludePlatforms": [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ImageTargetEnabler` uses `ARTrackablesChangedEventArgs<ARTrackedImage>`, whose `added`, `updated`, and `removed` collections are typed as `ReadOnlyList<>` from **Unity.XR.CoreUtils**. The runtime assembly definition did not reference that package, which produced **CS0012** (missing assembly for `ReadOnlyList<>`).

Without resolving `ReadOnlyList`, the compiler did not treat `.Count` as a property on the collection, which led to **CS0019** (`int` compared to a method group) on the `for` loops.

## Change

- Add `Unity.XR.CoreUtils` to `ArCar.Runtime.asmdef` references (the package is already pulled in transitively via AR Foundation in this project).

## Testing

Not run in this environment (Unity editor build). Recompile the project in Unity to confirm the errors are cleared.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a991aa99-e413-4c90-b71f-0caad107b3b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a991aa99-e413-4c90-b71f-0caad107b3b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

