### PR TITLE
fix(IoT): No console warning when Blynk token unset

### DIFF
--- a/AR Car Project/Assets/Scripts/Gameplay/IoT.cs
+++ b/AR Car Project/Assets/Scripts/Gameplay/IoT.cs
@@ -37,11 +37,7 @@ public sealed class IoT : MonoBehaviour
         closeStepBtn.onClick.AddListener(StopPollingDoorSensor);
 
         if (string.IsNullOrEmpty(_effectiveToken))
-        {
-            Debug.LogWarning(
-                "IoT: No Blynk token (Inspector, env BLYNK_TOKEN, or Resources/BlynkToken.txt). Brake lights and door sensor polling are disabled.");
-            return;
-        }
+            return; // Blynk optional: no token means brake lights / remote sensor stay off; door buttons still work above.
 
         string tokenParam = _effectiveToken;
         bckBtn.onClick.AddListener(() => StartCoroutine(UpdateValue($"{updateUrlBase}{tokenParam}&v1=1")));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`enhancement` already includes the IoT Blynk token resolution and optional `Resources` template. This PR adds the follow-up: when no token is configured, the IoT layer exits **without** `Debug.LogWarning`, so the app runs with a clean console when Blynk hardware is not in use.

## Changes
- Remove the missing-token warning; door buttons still wire for local animations.
- Full Blynk behavior (brake lights, door sensor polling) is unchanged when a token is set (Inspector, `BLYNK_TOKEN`, or `BlynkToken.txt`).

## Testing
Not run (Unity project).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4949c911-22ff-4255-86a5-c669f5b186af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4949c911-22ff-4255-86a5-c669f5b186af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

