### PR TITLE
Fix Android Gradle manifest merger: duplicate ARCore namespace

### DIFF
--- a/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs
+++ b/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs
@@ -4,20 +4,28 @@ using System.Text.RegularExpressions;
 using UnityEditor.Android;
 
 /// <summary>
-/// ARCore's arcore_client AAR and Unity's unityandroidpermissions AAR both declare
-/// AGP namespace/package com.google.ar.core. AGP 9 rejects that during manifest merge.
-/// Unity generates unityandroidpermissions/build.gradle next to unityLibrary; inject a
-/// unique namespace there after the Gradle project is emitted.
+/// Post-processes the Gradle project Unity exports before <c>gradlew</c> runs.
 /// </summary>
 class AndroidGradleArCoreNamespaceFix : IPostGenerateGradleAndroidProject
 {
     const string TargetNamespace = "com.unity3d.plugin.unityandroidpermissions";
+    const string UnityPlayerActivity = "com.unity3d.player.UnityPlayerActivity";
 
     public int callbackOrder => 0;
 
     public void OnPostGenerateGradleAndroidProject(string path)
     {
         string gradleRoot = Path.GetFullPath(Path.Combine(path, ".."));
+        FixUnityAndroidPermissionsNamespace(gradleRoot);
+        EnsureBuildAndRunLaunchesUnityPlayerActivity(gradleRoot);
+    }
+
+    /// <summary>
+    /// ARCore's arcore_client AAR and Unity's unityandroidpermissions AAR both declare
+    /// AGP namespace/package com.google.ar.core. AGP 9 rejects that during manifest merge.
+    /// </summary>
+    static void FixUnityAndroidPermissionsNamespace(string gradleRoot)
+    {
         string buildGradle = Path.Combine(gradleRoot, "unityandroidpermissions", "build.gradle");
         if (!File.Exists(buildGradle))
             return;
@@ -44,6 +52,54 @@ class AndroidGradleArCoreNamespaceFix : IPostGenerateGradleAndroidProject
         int insert = i + anchor.Length;
         string insertText = "\n    namespace '" + TargetNamespace + "'\n";
         File.WriteAllText(buildGradle, text.Insert(insert, insertText));
+    }
+
+    /// <summary>
+    /// Unity Editor "Build And Run" starts <see cref="UnityPlayerActivity"/> via ADB. If the
+    /// exported launcher manifest only declares <c>UnityPlayerGameActivity</c> (GameActivity
+    /// entry point), install succeeds but launch fails with "Activity class ... does not exist".
+    /// </summary>
+    static void EnsureBuildAndRunLaunchesUnityPlayerActivity(string gradleRoot)
+    {
+        string manifestPath = Path.Combine(gradleRoot, "launcher", "src", "main", "AndroidManifest.xml");
+        if (!File.Exists(manifestPath))
+            return;
+
+        string xml = File.ReadAllText(manifestPath);
+        if (xml.Contains("android:name=\"" + UnityPlayerActivity + "\"") || xml.Contains("android:name='" + UnityPlayerActivity + "'"))
+            return;
+
+        // Only rewrite the MAIN/LAUNCHER activity so we do not disturb other activity declarations.
+        var pattern = new Regex(
+            @"<activity\b[^>]*android:name\s*=\s*""com\.unity3d\.player\.UnityPlayerGameActivity""[^>]*>[\s\S]*?<intent-filter>[\s\S]*?android\.intent\.action\.MAIN[\s\S]*?android\.intent\.category\.LAUNCHER[\s\S]*?</intent-filter>[\s\S]*?</activity>",
+            RegexOptions.IgnoreCase);
+
+        Match m = pattern.Match(xml);
+        if (!m.Success)
+        {
+            pattern = new Regex(
+                @"<activity\b[^>]*android:name\s*=\s*'com\.unity3d\.player\.UnityPlayerGameActivity'[^>]*>[\s\S]*?<intent-filter>[\s\S]*?android\.intent\.action\.MAIN[\s\S]*?android\.intent\.category\.LAUNCHER[\s\S]*?</intent-filter>[\s\S]*?</activity>",
+                RegexOptions.IgnoreCase);
+            m = pattern.Match(xml);
+        }
+
+        if (!m.Success)
+            return;
+
+        string block = m.Value;
+        string newBlock = Regex.Replace(
+            block,
+            @"android:name\s*=\s*""com\.unity3d\.player\.UnityPlayerGameActivity""",
+            "android:name=\"" + UnityPlayerActivity + "\"",
+            RegexOptions.IgnoreCase);
+        newBlock = Regex.Replace(
+            newBlock,
+            @"android:name\s*=\s*'com\.unity3d\.player\.UnityPlayerGameActivity'",
+            "android:name=\"" + UnityPlayerActivity + "\"",
+            RegexOptions.IgnoreCase);
+
+        if (newBlock != block)
+            File.WriteAllText(manifestPath, xml.Substring(0, m.Index) + newBlock + xml.Substring(m.Index + m.Length));
     }
 }
 #endif

--- a/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs
+++ b/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs
@@ -1,0 +1,49 @@
+#if UNITY_EDITOR
+using System.IO;
+using System.Text.RegularExpressions;
+using UnityEditor.Android;
+
+/// <summary>
+/// ARCore's arcore_client AAR and Unity's unityandroidpermissions AAR both declare
+/// AGP namespace/package com.google.ar.core. AGP 9 rejects that during manifest merge.
+/// Unity generates unityandroidpermissions/build.gradle next to unityLibrary; inject a
+/// unique namespace there after the Gradle project is emitted.
+/// </summary>
+class AndroidGradleArCoreNamespaceFix : IPostGenerateGradleAndroidProject
+{
+    const string TargetNamespace = "com.unity3d.plugin.unityandroidpermissions";
+
+    public int callbackOrder => 0;
+
+    public void OnPostGenerateGradleAndroidProject(string path)
+    {
+        string gradleRoot = Path.GetFullPath(Path.Combine(path, ".."));
+        string buildGradle = Path.Combine(gradleRoot, "unityandroidpermissions", "build.gradle");
+        if (!File.Exists(buildGradle))
+            return;
+
+        string text = File.ReadAllText(buildGradle);
+        if (text.Contains("namespace '" + TargetNamespace + "'") || text.Contains("namespace \"" + TargetNamespace + "\""))
+            return;
+
+        if (Regex.IsMatch(text, @"namespace\s+['""]com\.google\.ar\.core['""]"))
+        {
+            text = Regex.Replace(
+                text,
+                @"namespace\s+['""]com\.google\.ar\.core['""]",
+                "namespace '" + TargetNamespace + "'");
+            File.WriteAllText(buildGradle, text);
+            return;
+        }
+
+        const string anchor = "android {";
+        int i = text.IndexOf(anchor);
+        if (i < 0)
+            return;
+
+        int insert = i + anchor.Length;
+        string insertText = "\n    namespace '" + TargetNamespace + "'\n";
+        File.WriteAllText(buildGradle, text.Insert(insert, insertText));
+    }
+}
+#endif

--- a/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs.meta
+++ b/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4d8e91f2a5b4c7d9e0f1a2b3c4d5e6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AR Car Project/Assets/Plugins/Android/baseProjectTemplate.gradle
+++ b/AR Car Project/Assets/Plugins/Android/baseProjectTemplate.gradle
@@ -10,9 +10,10 @@ plugins {
 
 // Work around duplicate Android namespace: both arcore_client and unityandroidpermissions
 // ship manifests with package/namespace com.google.ar.core. AGP 9 manifest merger rejects that.
+// (Also patched at export time by Assets/Editor/AndroidGradleArCoreNamespaceFix.cs; see gradleTemplate.properties.)
 subprojects { sub ->
-    sub.afterEvaluate {
-        if (sub.name == 'unityandroidpermissions' && sub.plugins.hasPlugin('com.android.library')) {
+    sub.plugins.withId('com.android.library') {
+        if (sub.name == 'unityandroidpermissions') {
             sub.android.namespace = 'com.unity3d.plugin.unityandroidpermissions'
         }
     }

--- a/AR Car Project/Assets/Plugins/Android/baseProjectTemplate.gradle
+++ b/AR Car Project/Assets/Plugins/Android/baseProjectTemplate.gradle
@@ -1,0 +1,23 @@
+plugins {
+    // If you are changing the Android Gradle Plugin version, make sure it is compatible with the Gradle version preinstalled with Unity
+    // See which Gradle version is preinstalled with Unity here https://docs.unity3d.com/Manual/android-gradle-overview.html
+    // See official Gradle and Android Gradle Plugin compatibility table here https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+    // To specify a custom Gradle version in Unity, go do "Preferences > External Tools", uncheck "Gradle Installed with Unity (recommended)" and specify a path to a custom Gradle version
+    id 'com.android.application' version '9.0.0' apply false
+    id 'com.android.library' version '9.0.0' apply false
+    **BUILD_SCRIPT_DEPS**
+}
+
+// Work around duplicate Android namespace: both arcore_client and unityandroidpermissions
+// ship manifests with package/namespace com.google.ar.core. AGP 9 manifest merger rejects that.
+subprojects { sub ->
+    sub.afterEvaluate {
+        if (sub.name == 'unityandroidpermissions' && sub.plugins.hasPlugin('com.android.library')) {
+            sub.android.namespace = 'com.unity3d.plugin.unityandroidpermissions'
+        }
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/AR Car Project/Assets/Plugins/Android/baseProjectTemplate.gradle.meta
+++ b/AR Car Project/Assets/Plugins/Android/baseProjectTemplate.gradle.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a8f3c21d4e6b4092b7c5d8e1f0a3b6c9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AR Car Project/Assets/Plugins/Android/gradleTemplate.properties
+++ b/AR Car Project/Assets/Plugins/Android/gradleTemplate.properties
@@ -1,0 +1,7 @@
+org.gradle.jvmargs=-Xmx**JVM_HEAP_SIZE**M
+org.gradle.parallel=true
+unityStreamingAssets=**STREAMING_ASSETS**
+**ADDITIONAL_PROPERTIES**
+# AGP 9: allow duplicate manifest package/namespace across legacy AARs (ARCore client + UnityAndroidPermissions).
+# Prefer removing this after Unity/Google ship non-overlapping artifacts. See android.uniquePackageNames in AGP 9 release notes.
+android.uniquePackageNames=false

--- a/AR Car Project/Assets/Plugins/Android/gradleTemplate.properties.meta
+++ b/AR Car Project/Assets/Plugins/Android/gradleTemplate.properties.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b7e2f09c8d1a4e6b9c3d5f8a0b2c4e6d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AR Car Project/ProjectSettings/ProjectSettings.asset
+++ b/AR Car Project/ProjectSettings/ProjectSettings.asset
@@ -264,7 +264,7 @@ PlayerSettings:
   useCustomLauncherManifest: 0
   useCustomMainGradleTemplate: 0
   useCustomLauncherGradleManifest: 0
-  useCustomBaseGradleTemplate: 0
+  useCustomBaseGradleTemplate: 1
   useCustomGradlePropertiesTemplate: 0
   useCustomGradleSettingsTemplate: 0
   useCustomProguardFile: 0

--- a/AR Car Project/ProjectSettings/ProjectSettings.asset
+++ b/AR Car Project/ProjectSettings/ProjectSettings.asset
@@ -265,7 +265,7 @@ PlayerSettings:
   useCustomMainGradleTemplate: 0
   useCustomLauncherGradleManifest: 0
   useCustomBaseGradleTemplate: 1
-  useCustomGradlePropertiesTemplate: 0
+  useCustomGradlePropertiesTemplate: 1
   useCustomGradleSettingsTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Gradle / AGP 9:** Resolved duplicate `com.google.ar.core` namespace between `arcore_client` and `unityandroidpermissions` (custom base Gradle template, `gradleTemplate.properties` with `android.uniquePackageNames=false`, and post-export `build.gradle` patch).
- **Build and Run:** Unity’s ADB launch uses `com.unity3d.player.UnityPlayerActivity`. When the exported launcher manifest registers only `UnityPlayerGameActivity` as MAIN/LAUNCHER, the APK installs but **Build and Run** fails with “Activity class … does not exist”. The `IPostGenerateGradleAndroidProject` callback now rewrites **only** that MAIN/LAUNCHER activity block to `UnityPlayerActivity` after Gradle export.

## Notes

- Player **Application Entry Point** remains **Activity** (`androidApplicationEntry: 1` = `AndroidApplicationEntry.Activity` in Unity’s flags enum). If you intentionally need GameActivity-only, say so; the manifest patch is meant to align the launcher with the Editor’s launch intent.
- After pull: clear `Library/Bee/Android` once if an old manifest is cached.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8886d7e0-abe6-4003-9a61-ff408b7d6238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8886d7e0-abe6-4003-9a61-ff408b7d6238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

