### PR TITLE
Fix Android Build And Run launch activity

### DIFF
--- a/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs
+++ b/AR Car Project/Assets/Editor/AndroidGradleArCoreNamespaceFix.cs
@@ -1,17 +1,29 @@
 #if UNITY_EDITOR
 using System.IO;
 using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
 using UnityEditor.Android;
 
 /// <summary>
-/// Post-processes the Gradle project Unity exports before <c>gradlew</c> runs.
+/// Applies Android build settings before Unity exports Gradle, then patches the generated project.
 /// </summary>
-class AndroidGradleArCoreNamespaceFix : IPostGenerateGradleAndroidProject
+class AndroidGradleArCoreNamespaceFix : IPreprocessBuildWithReport, IPostGenerateGradleAndroidProject
 {
     const string TargetNamespace = "com.unity3d.plugin.unityandroidpermissions";
     const string UnityPlayerActivity = "com.unity3d.player.UnityPlayerActivity";
 
     public int callbackOrder => 0;
+
+    public void OnPreprocessBuild(BuildReport report)
+    {
+        if (report.summary.platform != BuildTarget.Android)
+            return;
+
+        // Unity Build And Run launches UnityPlayerActivity through ADB for this project.
+        PlayerSettings.Android.applicationEntry = AndroidApplicationEntry.Activity;
+    }
 
     public void OnPostGenerateGradleAndroidProject(string path)
     {

--- a/AR Car Project/ProjectSettings/ProjectSettings.asset
+++ b/AR Car Project/ProjectSettings/ProjectSettings.asset
@@ -79,7 +79,7 @@ PlayerSettings:
   androidFullscreenMode: 1
   androidAutoRotationBehavior: 1
   androidPredictiveBackSupport: 1
-  androidApplicationEntry: 1
+  androidApplicationEntry: 2
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
   runInBackground: 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Persist Android Player Settings to use the Activity application entry point (`androidApplicationEntry: 2`) so Unity generates `com.unity3d.player.UnityPlayerActivity` before any build callbacks run.
- Force Android builds to use `AndroidApplicationEntry.Activity` during preprocessing as a guard against local setting drift.
- Keep the generated manifest fallback that rewrites a GameActivity launcher to `UnityPlayerActivity` if needed.

### Testing
- `python3` static validation confirmed the serialized Android entry point is set to `2`, the old `1` value is absent, and the pre-build hook still assigns `AndroidApplicationEntry.Activity`.
- `python3` manifest harness confirmed the fallback rewrites a generated `UnityPlayerGameActivity` launcher block to `UnityPlayerActivity`.
- `git diff --check` passed.

### Notes
- Unity and dotnet are not installed on this cloud image, so a full Unity Android Build And Run could not be executed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bd1bb07-7512-44cc-a78b-98bbc42032b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bd1bb07-7512-44cc-a78b-98bbc42032b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

